### PR TITLE
Revert "use yield instead of old fixture wrapping"

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,7 +27,11 @@ EXTENSION_DIR = str((Path(__file__).parent.parent).resolve())
 
 
 @pytest.fixture(scope="session")
-def postgres():
+def postgres(request):
+    def endup():
+        print("Database shutdown")
+        pg.shutdown()
+    request.addfinalizer(endup)
 
     pg = PyEmbedPg(POSTGRES_VERSION, config_options='--with-python').start(15432)
     pg.create_database('testdb')
@@ -45,10 +49,7 @@ def postgres():
 
     load_extensions(pg)
 
-    yield pg
-
-    print("Database shutdown")
-    pg.shutdown()
+    return pg
 
 
 def load_extensions(pg):


### PR DESCRIPTION
This reverts commit 283cef1af94fb3a5658b0051827d6f2c8d581013.

When an exception occurs in the setup, the function pg.shutdown() is never called, resulting in a postgres process still running in background. this is explained here : https://docs.pytest.org/en/latest/fixture.html#fixture-finalization-executing-teardown-code