### PR TITLE
Add a pg_li3ds Python package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .cache
 __pycache__
+*.egg-info

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,20 @@
+PIP_COMMAND ?= pip
+PIP_EDITABLE_MODE ?= FALSE
+PIP_INSTALL_OPTIONS = --upgrade
+ifeq ($(PIP_EDITABLE_MODE), TRUE)
+	PIP_INSTALL_OPTIONS += -e
+endif
+
 extdir=`pg_config --sharedir`/extension
 
-install:
+.PHONY: install
+install: install_extension install_python_package
+
+.PHONY: install_extension
+install_extension:
 	install -m 0644 extension/li3ds.control $(extdir)
 	install -m 0644 extension/li3ds--1.0.0.sql $(extdir)
 
+.PHONY: install_python_package
+install_python_package:
+	$(PIP_COMMAND) install $(PIP_INSTALL_OPTIONS) ./python

--- a/extension/li3ds--1.0.0.sql
+++ b/extension/li3ds--1.0.0.sql
@@ -494,16 +494,16 @@ $CODE$
     return pg_li3ds._transform_box4d(box4d, func_name, func_sign, params)
 $CODE$ language plpython2u;
 
-create or replace function transform(box libox4d, transfoid integer)
+create or replace function transform(box libox4d, transfoid integer, ttime float8 default 0.0)
 returns libox4d as
 $CODE$
     import pg_li3ds
-    return pg_li3ds.transform_box4d(box, transfoid)
+    return pg_li3ds.transform_box4d(box, transfoid, ttime)
 $CODE$ language plpython2u;
 
-create or replace function transform(patch pcpatch, transfoid integer)
+create or replace function transform(patch pcpatch, transfoid integer, ttime float8 default 0.0)
 returns pcpatch as
 $CODE$
     import pg_li3ds
-    return pg_li3ds.transform_patch(patch, transfoid)
+    return pg_li3ds.transform_patch(patch, transfoid, ttime)
 $CODE$ language plpython2u;

--- a/extension/li3ds--1.0.0.sql
+++ b/extension/li3ds--1.0.0.sql
@@ -488,69 +488,22 @@ $CODE$ language plpython2u;
 ---
 
 create or replace function transform(box libox4d, func_name text, func_sign text[], params text)
-returns text as
+returns libox4d as
 $CODE$
-    import json
-
-    _params = json.loads(params)
-
-    args = [_params[p] for p in func_sign if p != '_time']
-    args_str = ''
-    for arg in args:
-        args_str += ', '
-        if isinstance(arg, list):
-            args_str += 'ARRAY'
-        args_str += '{}'.format(arg)
-
-    q = 'select pc_{}(\'{}\'::LIBOX4D{}) r'.format(func_name, box, args_str)
-    rv = plpy.execute(q)
-    if len(rv) != 1:
-        plpy.error('unexpected returned value from {}'.format(q))
-    result = rv[0]['r']
-
-    return result
+    import pg_li3ds
+    return pg_li3ds._transform_box4d(box4d, func_name, func_sign, params)
 $CODE$ language plpython2u;
 
 create or replace function transform(box libox4d, transfoid integer)
 returns libox4d as
 $CODE$
-    import json
+    import pg_li3ds
+    return pg_li3ds.transform_box4d(box, transfoid)
+$CODE$ language plpython2u;
 
-    func_names = {
-        'affine_mat4x3': 'affine',
-        'affine_quat': 'affine',
-    }
-
-    q = '''
-        select t.name as name, t.parameters as params,
-               tt.name as func_name, tt.func_signature as func_sign
-        from li3ds.transfo t
-        join li3ds.transfo_type tt on t.transfo_type = tt.id
-        where t.id = {:d}
-        '''.format(transfoid)
-    rv = plpy.execute(q)
-    if len(rv) < 1:
-        plpy.error('no transfo with id {:d}'.format(transfoid))
-    transfo = rv[0]
-
-    func_name = transfo['func_name']
-    if func_name not in func_names:
-        plpy.error('function {} is unknown', func_name)
-    func_sign = transfo['func_sign']
-    params = json.loads(transfo['params'])
-
-    plpy.log('apply transfo {} (function: {}) to box'.format(
-        transfo['name'], func_name))
-
-    # assume the transfom is static for now
-    params = params[0]
-
-    q = "select li3ds.transform('{}'::LIBOX4D, '{}', ARRAY{}, '{}') r".format(
-        box, func_names[func_name], func_sign, json.dumps(params))
-    rv = plpy.execute(q)
-    if len(rv) != 1:
-        plpy.error('unexpected returned value from {}'.format(q))
-    result = rv[0]['r']
-
-    return result
+create or replace function transform(patch pcpatch, transfoid integer)
+returns pcpatch as
+$CODE$
+    import pg_li3ds
+    return pg_li3ds.transform_patch(patch, transfoid)
 $CODE$ language plpython2u;

--- a/python/pg_li3ds/__init__.py
+++ b/python/pg_li3ds/__init__.py
@@ -1,0 +1,76 @@
+# -*- coding: utf-8 -*-
+
+import plpy
+import json
+
+__version__ = '0.1.dev0'
+
+
+func_names = {
+    'affine_mat4x3': 'PC_Affine',
+    'affine_quat': 'PC_Affine',
+    'spherical_to_cartesian': 'PC_SphericalToCartesian',
+}
+
+
+def get_transform(transfoid):
+    ''' Return a dict with keys "name", "params", "func_name", and "func_sign".
+    '''
+    q = '''
+        select t.name as name, t.parameters as params,
+               tt.name as func_name, tt.func_signature as func_sign
+        from li3ds.transfo t
+        join li3ds.transfo_type tt on t.transfo_type = tt.id
+        where t.id = {:d}
+        '''.format(transfoid)
+    rv = plpy.execute(q)
+    if len(rv) < 1:
+        plpy.error('no transfo with id {:d}'.format(transfoid))
+    transfo = rv[0]
+    params = json.loads(transfo['params'])
+    if params:
+        params = params[0]  # assume the transform is static
+    return transfo['name'], params, transfo['func_name'], transfo['func_sign']
+
+
+def _transform(obj, type_, func_name, func_sign, params):
+    if func_name not in func_names:
+        plpy.error('function {} is unknown'.format(func_name))
+    func_name = func_names[func_name]
+    if isinstance(params, basestring):  # NOQA
+        params = json.loads(params)
+    args = [params[p] for p in func_sign if p != '_time']
+    args_str = ''
+    for arg in args:
+        args_str += ', '
+        if isinstance(arg, list):
+            args_str += 'ARRAY'
+        args_str += '{}'.format(arg)
+    q = 'select {}(\'{}\'::{}{}) r'.format(func_name, obj, type_, args_str)
+    rv = plpy.execute(q)
+    if len(rv) != 1:
+        plpy.error('unexpected returned value from {}'.format(q))
+    result = rv[0]['r']
+    return result
+
+
+def _transform_box4d(box4d, func_name, func_sign, params):
+    return _transform(box4d, 'LIBOX4D', func_name, func_sign, params)
+
+
+def _transform_patch(patch, func_name, func_sign, params):
+    return _transform(patch, 'PCPATCH', func_name, func_sign, params)
+
+
+def transform_box4d(box4d, transfoid):
+    transfo = get_transform(transfoid)
+    name, params, func_name, func_sign = transfo
+    plpy.log('apply transfo "{}" (function: "{}") to box4d'.format(name, func_name))
+    return _transform_box4d(box4d, func_name, func_sign, params)
+
+
+def transform_patch(patch, transfoid):
+    transfo = get_transform(transfoid)
+    name, params, func_name, func_sign = transfo
+    plpy.log('apply transfo "{}" (function: "{}") to patch'.format(name, func_name))
+    return _transform_patch(patch, func_name, func_sign, params)

--- a/python/pg_li3ds/__init__.py
+++ b/python/pg_li3ds/__init__.py
@@ -13,41 +13,137 @@ func_names = {
 }
 
 
-def get_transform(transfoid):
-    ''' Return a dict with keys "name", "params", "func_name", and "func_sign".
+def dim_name(dim):
+    ''' Return the dimension sign and name. '-' is returned when dim is negative and ''
+        when dim is positive.
+    '''
+    neg = ''
+    if dim[0] == '-':
+        neg = '-'
+        dim = dim[1:]
+    return neg, dim
+
+
+def append_dim_select(dim, select):
+    ''' Append the PC_Get fonction call string for "dim" to "select".
+    '''
+    neg, dim = dim_name(dim)
+    select.append('{}PC_Get(point, \'{}\') {}'.format(neg, dim, plpy.quote_ident(dim)))
+
+
+def get_dyn_transfo_params(params_column, params, time):
+    ''' Return the dynamic transfo parameters.
+    '''
+    schema, table, column = tuple(map(plpy.quote_ident, params_column.split('.')))
+    params = params[0]
+
+    select = []
+    for param in params.values():
+        if isinstance(param, list):
+            for dim in param:
+                append_dim_select(dim, select)
+        else:
+            dim = param
+            append_dim_select(dim, select)
+    select = ', '.join(select)
+
+    # TODO: we could do better with an index
+    q = ('''
+        with patch as (
+            select pc_interpolate({column}, 'time', {time:f}, true) point
+            from {schema}.{table}
+            where pc_patchmin({column}, 'time') < {time:f} and
+                  pc_patchmax({column}, 'time') > {time:f}
+        ) select %s from patch
+        ''' % select).format(schema=schema, table=table, column=column, time=time)
+    plpy.debug(q)
+    rv = plpy.execute(q)
+    if len(rv) == 0:
+        plpy.warning('no parameters for the provided time')
+        return None
+    if len(rv) != 1:
+        plpy.error('multiple rows returned from time interpolation')
+    values = rv[0]
+
+    for key, param in params.items():
+        if isinstance(param, list):
+            for i, dim in enumerate(param):
+                val = values[dim_name(dim)[1]]
+                param[i] = val
+        else:
+            dim = param
+            val = values[dim_name(dim)[1]]
+            params[key] = val
+
+    return params
+
+
+def get_transform(transfoid, time):
+    ''' Return information about the transfo whose id is transfoid. A dict with keys "name",
+        "params", "func_name", and "func_sign".
     '''
     q = '''
-        select t.name as name, t.parameters as params,
+        select t.name as name,
+               t.parameters_column as params_column, t.parameters as params,
                tt.name as func_name, tt.func_signature as func_sign
         from li3ds.transfo t
         join li3ds.transfo_type tt on t.transfo_type = tt.id
         where t.id = {:d}
         '''.format(transfoid)
+    plpy.debug(q)
     rv = plpy.execute(q)
     if len(rv) < 1:
         plpy.error('no transfo with id {:d}'.format(transfoid))
     transfo = rv[0]
+    params_column = transfo['params_column']
     params = json.loads(transfo['params'])
-    if params:
+    if params_column:
+        # dynamic transfo
+        if not time:
+            plpy.error('no time value provided for dynamic transfo "{}"'.format(transfo['name']))
+        params = get_dyn_transfo_params(params_column, params, time)
+        if params is None:
+            return None
+    elif params:
         params = params[0]  # assume the transform is static
     return transfo['name'], params, transfo['func_name'], transfo['func_sign']
 
 
+def args_to_array_string(args):
+    ''' Return args wrapped into ARRAY[]'s.
+    '''
+    args_str = ''
+    args_val = []
+    idx = 1
+    for arg in args:
+        args_str += ', '
+        if isinstance(arg, list):
+            str_ = 'ARRAY[{}]'.format(
+                 ','.join('${}'.format(idx + i) for i in range(len(arg))))
+            args_str += str_
+            args_val.extend(arg)
+            idx += len(arg)
+        else:
+            args_str += '$1'
+            args_val.append(arg)
+            idx += 1
+    return args_str, args_val
+
+
 def _transform(obj, type_, func_name, func_sign, params):
+    ''' Transform obj, whose type is type_, using func_name, func_sign and params.
+    '''
     if func_name not in func_names:
         plpy.error('function {} is unknown'.format(func_name))
     func_name = func_names[func_name]
     if isinstance(params, basestring):  # NOQA
         params = json.loads(params)
     args = [params[p] for p in func_sign if p != '_time']
-    args_str = ''
-    for arg in args:
-        args_str += ', '
-        if isinstance(arg, list):
-            args_str += 'ARRAY'
-        args_str += '{}'.format(arg)
+    args_str, args_val = args_to_array_string(args)
     q = 'select {}(\'{}\'::{}{}) r'.format(func_name, obj, type_, args_str)
-    rv = plpy.execute(q)
+    plpy.debug(q)
+    plan = plpy.prepare(q, ['numeric'] * len(args_val))
+    rv = plpy.execute(plan, args_val)
     if len(rv) != 1:
         plpy.error('unexpected returned value from {}'.format(q))
     result = rv[0]['r']
@@ -55,22 +151,36 @@ def _transform(obj, type_, func_name, func_sign, params):
 
 
 def _transform_box4d(box4d, func_name, func_sign, params):
+    ''' Transform the box4d, using func_name, func_sign and params.
+    '''
     return _transform(box4d, 'LIBOX4D', func_name, func_sign, params)
 
 
 def _transform_patch(patch, func_name, func_sign, params):
+    ''' Transform the patch, using func_name, func_sign and params.
+    '''
     return _transform(patch, 'PCPATCH', func_name, func_sign, params)
 
 
-def transform_box4d(box4d, transfoid):
-    transfo = get_transform(transfoid)
+def transform_box4d(box4d, transfoid, time):
+    ''' Transform the box4d, using transfoid and time. time is ignored if the transform
+        is static.
+    '''
+    transfo = get_transform(transfoid, time)
+    if not transfo:
+        return None
     name, params, func_name, func_sign = transfo
     plpy.log('apply transfo "{}" (function: "{}") to box4d'.format(name, func_name))
     return _transform_box4d(box4d, func_name, func_sign, params)
 
 
-def transform_patch(patch, transfoid):
-    transfo = get_transform(transfoid)
+def transform_patch(patch, transfoid, time):
+    ''' Transform the patch, using transfoid and time. time is ignored if the transform
+        is static.
+    '''
+    transfo = get_transform(transfoid, time)
+    if not transfo:
+        return None
     name, params, func_name, func_sign = transfo
     plpy.log('apply transfo "{}" (function: "{}") to patch'.format(name, func_name))
     return _transform_patch(patch, func_name, func_sign, params)

--- a/python/setup.py
+++ b/python/setup.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+import os
+import re
+from setuptools import setup, find_packages
+
+here = os.path.abspath(os.path.dirname(__file__))
+
+
+def find_version(*file_paths):
+    """
+    see https://github.com/pypa/sampleproject/blob/master/setup.py
+    """
+    with open(os.path.join(here, *file_paths), 'r') as f:
+        version_file = f.read()
+
+    # The version line must have the form
+    # __version__ = 'ver'
+    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
+                              version_file, re.M)
+    if version_match:
+        return version_match.group(1)
+    raise RuntimeError("Unable to find version string. "
+                       "Should be at the first line of __init__.py.")
+
+
+setup(
+    name='pg_li3ds',
+    version=find_version('pg_li3ds', '__init__.py'),
+    description="Python library for the pg_li3ds PostgreSQL extension",
+    url='https://github.com/LI3DS/pg_li3ds',
+    author='dev',
+    author_email='contact@oslandia.com',
+    license='GPLv3',
+    classifiers=[
+        'Development Status :: 3 - Alpha',
+        'Intended Audience :: Developers',
+        'Programming Language :: Python :: 2.7',
+    ],
+    packages=find_packages(),
+    install_requires=(),
+    include_package_data=True
+)

--- a/tools/create-db.sh
+++ b/tools/create-db.sh
@@ -5,7 +5,7 @@ set -e
 DBNAME="${DBNAME:=li3ds}"
 DBUSER="${DBUSER:=li3ds}"
 
-sudo make install
+sudo make install PIP_EDITABLE_MODE=TRUE PIP_COMMAND=/usr/bin/pip2
 
 sudo -u postgres dropdb --if-exists ${DBNAME}
 sudo -u postgres createdb -O ${DBUSER} ${DBNAME}


### PR DESCRIPTION
This adds a pg_li3ds Python package and changes the li3ds.transform functions to rely on functions defined in this package. This allows sharing code between plpython functions.